### PR TITLE
Start persisting UI state

### DIFF
--- a/client-v2/cypress/e2e/routing.cy.ts
+++ b/client-v2/cypress/e2e/routing.cy.ts
@@ -6,6 +6,8 @@ import {
 } from 'cypress/support/auth-helpers'
 import { testName } from 'cypress/support/helpers'
 
+const AUTH_TOKEN_KEY = 'rockket-auth-token'
+
 beforeEach(() => {
     cy.clearDb()
 })
@@ -80,11 +82,11 @@ describe('Routing', () => {
             cy.get(testName('workspace-page'))
             cy.window().then(() => {
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                const token = window.localStorage.getItem('todo-authToken')!
+                const token = window.localStorage.getItem(AUTH_TOKEN_KEY)!
 
                 cy.clearLocalStorage()
 
-                cy.setLocalStorage('todo-authToken', token)
+                cy.setLocalStorage(AUTH_TOKEN_KEY, token)
                 cy.visit('/home')
 
                 cy.get(testName('workspace-page')).should('exist')

--- a/client-v2/src/app/components/molecules/page-progress-bar/page-progress-bar.component.html
+++ b/client-v2/src/app/components/molecules/page-progress-bar/page-progress-bar.component.html
@@ -16,7 +16,7 @@
     <button
         class="progress-number | font-bold text-tinted-600 transition-colors"
         [class.!text-submit-400]="digest.all && digest.closed == digest.all"
-        (click)="isShownAsPercentage = !isShownAsPercentage"
+        (click)="toggleShownAsPercentage()"
         [appTooltip]="isShownAsPercentage ? 'Display as fraction' : 'Display as percentage'"
         [tooltipOptions]="{ avoidPositions: ['left'] }"
     >

--- a/client-v2/src/app/components/molecules/page-progress-bar/page-progress-bar.component.spec.ts
+++ b/client-v2/src/app/components/molecules/page-progress-bar/page-progress-bar.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { UiStateService } from 'src/app/services/ui-state.service'
+import { actionsMock } from 'src/app/utils/unit-test.mocks'
 import { EntityViewComponent } from '../../organisms/entity-view/entity-view.component'
 
 import { PageProgressBarComponent } from './page-progress-bar.component'
@@ -13,6 +15,8 @@ describe('TaskProgressBarComponent', () => {
             providers: [
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 { provide: EntityViewComponent, useValue: { progress$: { next() {} } } },
+                UiStateService,
+                actionsMock,
             ],
         }).compileComponents()
 

--- a/client-v2/src/app/components/molecules/page-progress-bar/page-progress-bar.component.ts
+++ b/client-v2/src/app/components/molecules/page-progress-bar/page-progress-bar.component.ts
@@ -13,6 +13,7 @@ import {
     timer,
 } from 'rxjs'
 import { TaskPreview, TaskPreviewRecursive, TaskStatus } from 'src/app/fullstack-shared-models/task.model'
+import { UiStateService } from 'src/app/services/ui-state.service'
 import { taskStatusColorMap, TwColorClass } from 'src/app/shared/colors'
 import { EntityViewComponent } from '../../organisms/entity-view/entity-view.component'
 
@@ -56,7 +57,8 @@ const getStatusCountMapRecursive = (taskTree: TaskPreviewRecursive[]): Record<Ta
 })
 export class PageProgressBarComponent {
     constructor(
-        private entityView: EntityViewComponent // needed to update the secondary progress bar, @TODO: find a clearer way to do this
+        private entityView: EntityViewComponent, // needed to update the secondary progress bar, @TODO: find a clearer way to do this
+        private uiStateService: UiStateService
     ) {}
 
     taskStatuses = Object.values(TaskStatus)
@@ -71,7 +73,11 @@ export class PageProgressBarComponent {
         this.taskTree$.next(tasks)
     }
 
-    isShownAsPercentage = true
+    isShownAsPercentage = this.uiStateService.mainViewUiState.isProgressShownAsPercentage
+    toggleShownAsPercentage() {
+        this.isShownAsPercentage = !this.isShownAsPercentage
+        this.uiStateService.updateShownAsPercentage(this.isShownAsPercentage)
+    }
 
     digest$ = this.taskTree$.pipe(
         map(tasks => {

--- a/client-v2/src/app/components/templates/sidebar-layout/menu-toggle/menu-toggle.component.spec.ts
+++ b/client-v2/src/app/components/templates/sidebar-layout/menu-toggle/menu-toggle.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { UiStateService } from 'src/app/services/ui-state.service'
+import { actionsMock } from 'src/app/utils/unit-test.mocks'
 
 import { MenuToggleComponent } from './menu-toggle.component'
 
@@ -9,6 +11,7 @@ describe('MenuToggleComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             declarations: [MenuToggleComponent],
+            providers: [UiStateService, actionsMock],
         }).compileComponents()
 
         fixture = TestBed.createComponent(MenuToggleComponent)

--- a/client-v2/src/app/components/templates/sidebar-layout/menu.service.spec.ts
+++ b/client-v2/src/app/components/templates/sidebar-layout/menu.service.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing'
+import { UiStateService } from 'src/app/services/ui-state.service'
+import { actionsMock } from 'src/app/utils/unit-test.mocks'
 
 import { MenuService } from './menu.service'
 
@@ -6,7 +8,9 @@ describe('MenuService', () => {
     let service: MenuService
 
     beforeEach(() => {
-        TestBed.configureTestingModule({})
+        TestBed.configureTestingModule({
+            providers: [MenuService, UiStateService, actionsMock],
+        })
         service = TestBed.inject(MenuService)
     })
 

--- a/client-v2/src/app/components/templates/sidebar-layout/menu.service.ts
+++ b/client-v2/src/app/components/templates/sidebar-layout/menu.service.ts
@@ -1,21 +1,28 @@
 import { Injectable } from '@angular/core'
 import { BehaviorSubject } from 'rxjs'
+import { UiStateService } from 'src/app/services/ui-state.service'
 
 @Injectable({
     providedIn: 'root',
 })
 export class MenuService {
-    private _isMenuOpen = new BehaviorSubject(true)
+    constructor(private uiStateService: UiStateService) {
+        this.isMenuOpen$_.subscribe(isOpen => {
+            this.uiStateService.toggleMobileMenu(isOpen)
+        })
+    }
+
+    private isMenuOpen$_ = new BehaviorSubject(this.uiStateService.sidebarUiState.isMobileMenuOpen)
     get isMenuOpen$() {
-        return this._isMenuOpen
+        return this.isMenuOpen$_
     }
 
     setIsOpen(isOpen: boolean) {
-        this._isMenuOpen.next(isOpen)
+        this.isMenuOpen$_.next(isOpen)
     }
 
     toggleIsOpen() {
-        this._isMenuOpen.next(!this._isMenuOpen.value)
+        this.isMenuOpen$_.next(!this.isMenuOpen$_.value)
     }
 
     isBottomNavBorderVisible$ = new BehaviorSubject(false)

--- a/client-v2/src/app/components/templates/sidebar-layout/sidebar-layout.component.html
+++ b/client-v2/src/app/components/templates/sidebar-layout/sidebar-layout.component.html
@@ -1,10 +1,11 @@
 <div class="height-screen flex w-full flex-col" data-test-name="app-container" style="--bottom-nav-height: 3.5rem">
     <div class="relative flex h-[calc(100%-var(--bottom-nav-height))] md:h-full">
         <aside
-            class="sidebar | sidebar--mobile | relative flex h-full flex-col border-tinted-700 bg-tinted-800 md:w-56 md:min-w-[10rem] md:max-w-[25rem] md:border-r md:text-md"
+            class="sidebar | sidebar--mobile | relative flex h-full flex-col border-tinted-700 bg-tinted-800 md:w-[var(--sidebar-width,14rem)] md:min-w-[10rem] md:max-w-[25rem] md:border-r md:text-md"
             [class.hide]="!(isMenuOpen$ | async)"
             [hidden]="!(isMenuOpen$ | async)"
             data-test-name="sidebar"
+            [style.--sidebar-width]="uiState.width"
         >
             <div
                 *ngIf="enableResize"

--- a/client-v2/src/app/components/templates/sidebar-layout/sidebar-layout.component.spec.ts
+++ b/client-v2/src/app/components/templates/sidebar-layout/sidebar-layout.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { UiStateService } from 'src/app/services/ui-state.service'
+import { actionsMock } from 'src/app/utils/unit-test.mocks'
 
 import { SidebarLayoutComponent } from './sidebar-layout.component'
 
@@ -9,6 +11,7 @@ describe('SidebarLayoutComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             declarations: [SidebarLayoutComponent],
+            providers: [UiStateService, actionsMock],
         }).compileComponents()
     })
 

--- a/client-v2/src/app/components/templates/sidebar-layout/sidebar-layout.component.test.ts
+++ b/client-v2/src/app/components/templates/sidebar-layout/sidebar-layout.component.test.ts
@@ -1,7 +1,8 @@
 import { CdkMenuTrigger } from '@angular/cdk/menu'
 import { OverlayModule } from '@angular/cdk/overlay'
-import { Store } from '@ngrx/store'
 import { testName } from 'cypress/support/helpers'
+import { UiStateService } from 'src/app/services/ui-state.service'
+import { actionsMock, storeMock } from 'src/app/utils/unit-test.mocks'
 import { IconComponent } from '../../atoms/icons/icon/icon.component'
 import { LoadingSpinnerComponent } from '../../atoms/icons/loading-spinner/loading-spinner.component'
 import { UserMenuComponent } from '../../organisms/user-menu/user-menu.component'
@@ -12,10 +13,7 @@ import { SidebarLayoutComponent } from './sidebar-layout.component'
 const setupComponent = (template: string) => {
     cy.mount(template, {
         componentProperties: {},
-        providers: [
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            { provide: Store, useValue: { subscribe() {}, select() {} } },
-        ],
+        providers: [storeMock, UiStateService, actionsMock],
         imports: [OverlayModule],
         declarations: [
             SidebarLayoutComponent,

--- a/client-v2/src/app/components/templates/sidebar-layout/sidebar-layout.component.ts
+++ b/client-v2/src/app/components/templates/sidebar-layout/sidebar-layout.component.ts
@@ -1,7 +1,8 @@
 import { AfterViewInit, Component, ElementRef, Input, ViewChild } from '@angular/core'
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy'
-import { fromEvent, switchMap, takeUntil, tap } from 'rxjs'
+import { debounceTime, fromEvent, map, switchMap, takeUntil, tap } from 'rxjs'
 import { DeviceService } from 'src/app/services/device.service'
+import { UiStateService } from 'src/app/services/ui-state.service'
 import { MenuService } from './menu.service'
 
 @UntilDestroy()
@@ -11,7 +12,11 @@ import { MenuService } from './menu.service'
     styleUrls: ['./sidebar-layout.component.css'],
 })
 export class SidebarLayoutComponent implements AfterViewInit {
-    constructor(private menuService: MenuService, private deviceService: DeviceService) {}
+    constructor(
+        private menuService: MenuService,
+        private deviceService: DeviceService,
+        private uiStateService: UiStateService
+    ) {}
 
     @Input() enableResize = true
 
@@ -25,25 +30,30 @@ export class SidebarLayoutComponent implements AfterViewInit {
         this.isSidebarScrolled = !isIntersecting
     }
 
+    uiState = this.uiStateService.sidebarUiState
+
     @ViewChild('resizeHandle') resizeHandle!: ElementRef<HTMLDivElement>
 
     ngAfterViewInit(): void {
         if (!this.enableResize) return
 
-        this.setupResize().subscribe()
+        this.setupResize()
     }
 
     setupResize = () =>
-        fromEvent(this.resizeHandle.nativeElement, 'mousedown').pipe(
-            switchMap(() =>
-                fromEvent<MouseEvent>(document, 'mousemove').pipe(takeUntil(fromEvent(document, 'mouseup')))
-            ),
-            tap(e => {
-                const sidebar = this.resizeHandle.nativeElement.parentElement as HTMLDivElement
-                const currMouseX = e.clientX
-                const newWidth = currMouseX + 'px'
-                sidebar.style.width = newWidth
-            }),
-            untilDestroyed(this)
-        )
+        fromEvent(this.resizeHandle.nativeElement, 'mousedown')
+            .pipe(
+                switchMap(() =>
+                    fromEvent<MouseEvent>(document, 'mousemove').pipe(takeUntil(fromEvent(document, 'mouseup')))
+                ),
+                map(e => e.clientX + 'px'), // just take the x coordinate as the new width
+                tap(width => {
+                    const sidebar = this.resizeHandle.nativeElement.parentElement as HTMLDivElement
+                    sidebar.style.width = width
+                }),
+                debounceTime(600),
+                tap(width => this.uiStateService.updateSidebarWidth(width)),
+                untilDestroyed(this)
+            )
+            .subscribe()
 }

--- a/client-v2/src/app/pages/home/home.component.html
+++ b/client-v2/src/app/pages/home/home.component.html
@@ -98,7 +98,7 @@
                                 class="node-toggle"
                                 cdkTreeNodeToggle
                                 [attr.aria-label]="'Toggle ' + node.title"
-                                (click)="node.isExpanded = !node.isExpanded"
+                                (click)="toggleExpansion(node)"
                             >
                                 <app-icon
                                     icon="fas fa-chevron-right"

--- a/client-v2/src/app/pages/home/home.component.ts
+++ b/client-v2/src/app/pages/home/home.component.ts
@@ -11,13 +11,14 @@ import { EntityPreviewFlattend, EntityType } from 'src/app/fullstack-shared-mode
 import { TaskPreview } from 'src/app/fullstack-shared-models/task.model'
 import { DeviceService } from 'src/app/services/device.service'
 import { LoadingStateService } from 'src/app/services/loading-state.service'
+import { UiStateService } from 'src/app/services/ui-state.service'
 import { getEntityMenuItemsMap } from 'src/app/shared/entity-menu-items'
 import { AppState } from 'src/app/store'
 import { entitiesActions } from 'src/app/store/entities/entities.actions'
 import { entitiesSelectors } from 'src/app/store/entities/entities.selectors'
 import { listActions } from 'src/app/store/entities/list/list.actions'
 import { taskActions } from 'src/app/store/entities/task/task.actions'
-import { flattenEntityTreeIncludingTasks, traceEntity } from 'src/app/store/entities/utils'
+import { flattenEntityTreeIncludingTasks, traceEntity, traceEntityIncludingTasks } from 'src/app/store/entities/utils'
 import { useTaskForActiveItems } from 'src/app/utils/menu-item.helpers'
 
 export interface EntityTreeNode {
@@ -37,7 +38,7 @@ export const convertToEntityTreeNode = (entity: EntityPreviewFlattend): EntityTr
     const node: EntityTreeNode = {
         ...restEntity,
         expandable: (childrenCount || 0) > 0,
-        isExpanded: restEntity.path.length < 2,
+        isExpanded: false,
         menuItems: [],
     }
     return node
@@ -54,7 +55,8 @@ export class HomeComponent {
         private store: Store<AppState>,
         private loadingService: LoadingStateService,
         private deviceService: DeviceService,
-        private menuService: MenuService
+        private menuService: MenuService,
+        private uiStateService: UiStateService
     ) {}
 
     EntityType = EntityType
@@ -101,6 +103,12 @@ export class HomeComponent {
         return true
     }
 
+    entityExpandedMap = this.uiStateService.sidebarUiState.entityExpandedMap
+    toggleExpansion(node: EntityTreeNode) {
+        node.isExpanded = !node.isExpanded
+        this.uiStateService.toggleSidebarEntity(node.id, node.isExpanded)
+    }
+
     range(number: number) {
         return new Array(number)
     }
@@ -123,13 +131,17 @@ export class HomeComponent {
                 const flattendEntityTree = flattenEntityTreeIncludingTasks(entityTree, taskTreeMap || {})
                 const treeNodes = flattendEntityTree.map(convertToEntityTreeNode)
 
-                const [, ...entityTraceWithoutActive] = traceEntity(entityTree, activeId).reverse()
+                const [, ...entityTraceWithoutActive] = traceEntityIncludingTasks(
+                    entityTree,
+                    taskTreeMap || {},
+                    activeId
+                ).reverse()
 
                 return treeNodes.map<EntityTreeNode>(node => {
                     const isContainedInTrace = entityTraceWithoutActive.some(entity => entity.id == node.id)
                     return {
                         ...node,
-                        isExpanded: node.isExpanded || isContainedInTrace,
+                        isExpanded: this.entityExpandedMap.get(node.id) || isContainedInTrace,
                         menuItems: this.nodeMenuItemsMap[node.entityType].map(
                             useTaskForActiveItems(node as EntityTreeNode & TaskPreview)
                         ),

--- a/client-v2/src/app/pages/home/home.component.ts
+++ b/client-v2/src/app/pages/home/home.component.ts
@@ -18,7 +18,7 @@ import { entitiesActions } from 'src/app/store/entities/entities.actions'
 import { entitiesSelectors } from 'src/app/store/entities/entities.selectors'
 import { listActions } from 'src/app/store/entities/list/list.actions'
 import { taskActions } from 'src/app/store/entities/task/task.actions'
-import { flattenEntityTreeIncludingTasks, traceEntity, traceEntityIncludingTasks } from 'src/app/store/entities/utils'
+import { flattenEntityTreeIncludingTasks, traceEntityIncludingTasks } from 'src/app/store/entities/utils'
 import { useTaskForActiveItems } from 'src/app/utils/menu-item.helpers'
 
 export interface EntityTreeNode {

--- a/client-v2/src/app/services/auth.service.ts
+++ b/client-v2/src/app/services/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core'
 import { HttpService } from '../http/http.service'
 import { SignupCredentialsDto, LoginCredentialsDto } from '../fullstack-shared-models/auth.model'
 import { AuthSuccessResponse } from '../shared/models'
+import { StorageItem } from '../utils/storage.helpers'
 
 @Injectable({
     providedIn: 'root',
@@ -19,13 +20,14 @@ export class AuthService {
         return this.http.get<AuthSuccessResponse>('/auth/me')
     }
 
+    private token = new StorageItem<string>('rockket-auth-token', { oldKey: 'todo-authToken' })
     getToken() {
-        return localStorage.getItem('todo-authToken')
+        return this.token.value
     }
     saveToken(authToken: string) {
-        localStorage.setItem('todo-authToken', authToken)
+        this.token.value = authToken
     }
     deleteToken() {
-        localStorage.removeItem('todo-authToken')
+        this.token.remove()
     }
 }

--- a/client-v2/src/app/services/device.service.ts
+++ b/client-v2/src/app/services/device.service.ts
@@ -48,6 +48,7 @@ export class DeviceService {
 
     shouldFetch$ = merge(this.isOnline$, this.isAppVisible$).pipe(
         distinctUntilChanged(),
+        startWith(true),
         throttleTime(15000),
         filter(event => event == true),
         map((_, index) => index),

--- a/client-v2/src/app/services/ui-state.service.spec.ts
+++ b/client-v2/src/app/services/ui-state.service.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing'
+import { actionsMock } from '../utils/unit-test.mocks'
+
+import { UiStateService } from './ui-state.service'
+
+describe('UiStateService', () => {
+    let service: UiStateService
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [actionsMock],
+        })
+        service = TestBed.inject(UiStateService)
+    })
+
+    it('should be created', () => {
+        expect(service).toBeTruthy()
+    })
+})

--- a/client-v2/src/app/services/ui-state.service.ts
+++ b/client-v2/src/app/services/ui-state.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@angular/core'
+import { Actions, ofType } from '@ngrx/effects'
+import { environment } from 'src/environments/environment'
+import { EntityType } from '../fullstack-shared-models/entities.model'
+import { entitiesActions } from '../store/entities/entities.actions'
+import { StorageItem } from '../utils/storage.helpers'
+
+class SidebarUiState {
+    isDesktopSidebarOpen = true
+    isMobileMenuOpen = true
+    width?: string
+
+    entityExpandedMap: Map<string, boolean> = new Map()
+
+    appVersion = environment.PACKAGE_VERSION
+}
+
+class MainViewUiState {
+    isProgressBarSticky = true
+    isProgressShownAsPercentage = true
+
+    entityExpandedMap: Map<string, boolean> = new Map()
+    taskTreeDescriptionExpandedMap: Map<string, boolean> = new Map()
+
+    appVersion = environment.PACKAGE_VERSION
+}
+
+@Injectable({
+    providedIn: 'root',
+})
+export class UiStateService {
+    constructor(private actions$: Actions) {}
+
+    private entityDeletedSubscription = this.actions$
+        .pipe(ofType(entitiesActions.deleteSuccess))
+        .subscribe(({ id, entityType }) => this.deleteUiEntryForEntity(id, entityType))
+
+    private sidebarUiState_ = new StorageItem('rockket-sidebar-ui-state', { defaultValue: new SidebarUiState() })
+    get sidebarUiState() {
+        return this.sidebarUiState_.value as SidebarUiState
+    }
+
+    private mainViewUiState_ = new StorageItem('rockket-main-ui-state', { defaultValue: new MainViewUiState() })
+    get mainViewUiState() {
+        return this.mainViewUiState_.value as MainViewUiState
+    }
+
+    toggleSidebarEntity(id: string, isExpanded: boolean) {
+        this.sidebarUiState.entityExpandedMap.set(id, isExpanded)
+        this.sidebarUiState_.updateStorage()
+    }
+    updateSidebarWidth(width: string) {
+        this.sidebarUiState.width = width
+        this.sidebarUiState_.updateStorage()
+    }
+    toggleMobileMenu(isOpen: boolean) {
+        this.sidebarUiState.isMobileMenuOpen = isOpen
+        this.sidebarUiState_.updateStorage()
+    }
+
+    toggleMainViewEntity(id: string, isExpanded: boolean) {
+        this.mainViewUiState.entityExpandedMap.set(id, isExpanded)
+        this.mainViewUiState_.updateStorage()
+    }
+    toggleTaskDescription(id: string, isExpanded: boolean) {
+        this.mainViewUiState.taskTreeDescriptionExpandedMap.set(id, isExpanded)
+        this.mainViewUiState_.updateStorage()
+    }
+    updateShownAsPercentage(isShownAsPercentage: boolean) {
+        this.mainViewUiState.isProgressShownAsPercentage = isShownAsPercentage
+        this.mainViewUiState_.updateStorage()
+    }
+
+    deleteUiEntryForEntity(id: string, entityType: EntityType) {
+        this.sidebarUiState.entityExpandedMap.delete(id)
+        this.mainViewUiState.entityExpandedMap.delete(id)
+        if (entityType == EntityType.TASK) this.mainViewUiState.taskTreeDescriptionExpandedMap.delete(id)
+
+        this.sidebarUiState_.updateStorage()
+        this.mainViewUiState_.updateStorage()
+    }
+    deleteUiState() {
+        this.sidebarUiState_.remove()
+        this.mainViewUiState_.remove()
+    }
+}

--- a/client-v2/src/app/utils/serialization.helpers.ts
+++ b/client-v2/src/app/utils/serialization.helpers.ts
@@ -1,0 +1,39 @@
+export type TypeProxy =
+    | {
+          __dataType: 'Map'
+          value: Record<string, unknown>
+      }
+    | {
+          __dataType: 'Set'
+          value: Array<unknown>
+      }
+
+export const isTypeProxy = (value: unknown): value is TypeProxy => {
+    return typeof value == 'object' && value !== null && '__dataType' in value
+}
+
+export const replacer = (_key: string, value: unknown) => {
+    if (value instanceof Map) {
+        return {
+            __dataType: 'Map',
+            value: Object.fromEntries(value),
+        }
+    }
+    if (value instanceof Set) {
+        return {
+            __dataType: 'Set',
+            value: Array.from(value),
+        }
+    }
+
+    return value
+}
+
+export const reviver = (_key: string, value: unknown) => {
+    if (!isTypeProxy(value)) return value
+
+    if (value.__dataType == 'Map') return new Map(Object.entries(value.value))
+    if (value.__dataType == 'Set') return new Set(value.value)
+
+    return value
+}

--- a/client-v2/src/app/utils/storage.helpers.ts
+++ b/client-v2/src/app/utils/storage.helpers.ts
@@ -1,0 +1,63 @@
+import { replacer, reviver } from './serialization.helpers'
+
+interface StorageInterfaceOptions<T> {
+    defaultValue?: T
+    /** Will use `localStorage` by default. */
+    storage?: 'localStorage' | 'sessionStorage'
+    /** A key used in previous versions of the app to migrate from. */
+    oldKey?: string
+}
+
+export class StorageItem<T> {
+    constructor(private key: string, private options: StorageInterfaceOptions<T> = {}) {}
+
+    private storage = window[this.options.storage || 'localStorage']
+
+    private value_: T | null = null
+    get value() {
+        if (this.value_ === null) this.value_ = this.getParsedValue()
+
+        return this.value_
+    }
+    set value(value: T | null) {
+        this.value_ = value
+        this.updateStorage()
+    }
+
+    /** Use this to manually update the storage item, when the `setter` cannot be triggered (e.g. when updating objects). */
+    updateStorage() {
+        if (this.value_ === null || this.value_ === undefined) {
+            this.remove()
+            return
+        }
+
+        this.storage.setItem(this.key, JSON.stringify(this.value_, replacer))
+    }
+
+    /** Remove the item from storage. */
+    remove() {
+        this.storage.removeItem(this.key)
+    }
+
+    private getParsedValue() {
+        const raw = this.getRawValue()
+        if (!raw) return this.options.defaultValue ?? null
+
+        try {
+            return JSON.parse(raw, reviver) as T
+        } catch {
+            return this.options.defaultValue ?? null
+        }
+    }
+
+    private getRawValue() {
+        if (!this.options.oldKey) return this.storage.getItem(this.key)
+
+        const value = this.storage.getItem(this.options.oldKey)
+        if (!value) return this.storage.getItem(this.key)
+
+        this.storage.removeItem(this.options.oldKey)
+        this.storage.setItem(this.key, value)
+        return value
+    }
+}


### PR DESCRIPTION
### Changes/Additions (partially implements #93)
- Add serialisation helpers
- Add localStorage abstraction class `StorageItem`
- Add `UIStateService`
    - Implement in `task-tree` (task expansion state)
    - Implement in `sidebar-layout` (width)
        - Implement in `menu.service` (isMobileMenuOpen)
    - Implement in `home` (entity expansion state)
    - Implement in `page-progress-bar` (percentage/fraction toggle)
- Use `StorageItem` in `auth.service` (auth token)
- 🚑️ Force device.service to emit in `shouldFetch$` on startup