### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/client-v2/cypress/e2e/auth.cy.ts
+++ b/client-v2/cypress/e2e/auth.cy.ts
@@ -1,5 +1,5 @@
 import { credentials } from 'cypress/fixtures/user-credentials'
-import { login, signup } from 'cypress/support/auth-helpers'
+import { loginProcedure, signupProcedure } from 'cypress/support/auth-helpers'
 import { testName } from 'cypress/support/helpers'
 
 beforeEach(() => {
@@ -9,14 +9,14 @@ beforeEach(() => {
 describe('Authentication', () => {
     describe('Signup', () => {
         it('can sign up', () => {
-            signup()
+            signupProcedure()
             cy.get(testName('user-menu-toggle')).invoke('attr', 'data-logged-in').should('eq', 'true')
         })
         it('cannot signup up with the same email twice', () => {
-            signup()
-            cy.visit('about:blank')
+            cy.signup()
+            cy.clearLocalStorage()
 
-            signup()
+            signupProcedure()
             cy.get(testName('signup-page'))
             cy.get(testName('workspace-page')).should('not.exist')
             cy.get(testName('user-menu-toggle')).should('not.exist')
@@ -25,25 +25,28 @@ describe('Authentication', () => {
 
     describe('Login', () => {
         it('can login', () => {
-            signup()
-            cy.visit('about:blank')
+            // this should not be necessary, but somehow a previous `signup` call from within `beforeEach` prevents the following signup
+            cy.clearDb()
 
-            login()
+            cy.signup()
+            cy.clearLocalStorage()
+
+            loginProcedure()
             cy.get(testName('user-menu-toggle')).invoke('attr', 'data-logged-in').should('eq', 'true')
         })
         it('cannot login with the wrong email', () => {
-            signup()
-            cy.visit('about:blank')
+            cy.signup()
+            cy.clearLocalStorage()
 
-            login({ ...credentials['jonathan'], email: 'some.other@email.com' })
+            loginProcedure({ ...credentials['jonathan'], email: 'some.other@email.com' })
             cy.get(testName('workspace-page')).should('not.exist')
             cy.get(testName('user-menu-toggle')).should('not.exist')
         })
         it('cannot login with the wrong password', () => {
-            signup()
-            cy.visit('about:blank')
+            cy.signup()
+            cy.clearLocalStorage()
 
-            login({ ...credentials['jonathan'], password: 'someOtherPwd-123' })
+            loginProcedure({ ...credentials['jonathan'], password: 'someOtherPwd-123' })
             cy.get(testName('workspace-page')).should('not.exist')
             cy.get(testName('user-menu-toggle')).should('not.exist')
         })

--- a/client-v2/cypress/e2e/workspace.cy.ts
+++ b/client-v2/cypress/e2e/workspace.cy.ts
@@ -1,9 +1,9 @@
-import { signup } from 'cypress/support/auth-helpers'
 import { testName } from 'cypress/support/helpers'
 
 beforeEach(() => {
     cy.clearDb()
-    signup()
+    cy.signup()
+    cy.visit('/home')
 
     cy.intercept('POST', '/list').as('createEntity')
     cy.intercept('POST', '/task').as('createTask')

--- a/client-v2/cypress/support/auth-helpers.ts
+++ b/client-v2/cypress/support/auth-helpers.ts
@@ -2,10 +2,10 @@ import { credentials, Credentials } from 'cypress/fixtures/user-credentials'
 import { testName } from './helpers'
 
 export const typeSignupCredentialsAndSubmit = (creds: Credentials = credentials['jonathan']) => {
-    cy.get(testName('input-username')).type(creds.username)
-    cy.get(testName('input-email')).type(creds.email)
-    cy.get(testName('input-password')).type(creds.password)
-    cy.get(testName('input-confirmPassword')).type(creds.password)
+    cy.get(testName('input-username')).type(creds.username, { delay: 5 })
+    cy.get(testName('input-email')).type(creds.email, { delay: 5 })
+    cy.get(testName('input-password')).type(creds.password, { delay: 5 })
+    cy.get(testName('input-confirmPassword')).type(creds.password, { delay: 5 })
     cy.get(testName('submit-button')).click()
 }
 export const signupProcedure = (creds: Credentials = credentials['jonathan']) => {
@@ -17,8 +17,8 @@ export const signupProcedure = (creds: Credentials = credentials['jonathan']) =>
 }
 
 export const typeLoginCredentialsAndSubmit = (creds: Credentials = credentials['jonathan']) => {
-    cy.get(testName('input-email')).type(creds.email)
-    cy.get(testName('input-password')).type(creds.password)
+    cy.get(testName('input-email')).type(creds.email, { delay: 5 })
+    cy.get(testName('input-password')).type(creds.password, { delay: 5 })
     cy.get(testName('submit-button')).click()
 }
 export const loginProcedure = (creds: Credentials = credentials['jonathan']) => {

--- a/client-v2/cypress/support/auth-helpers.ts
+++ b/client-v2/cypress/support/auth-helpers.ts
@@ -8,9 +8,11 @@ export const typeSignupCredentialsAndSubmit = (creds: Credentials = credentials[
     cy.get(testName('input-confirmPassword')).type(creds.password)
     cy.get(testName('submit-button')).click()
 }
-export const signup = (creds: Credentials = credentials['jonathan']) => {
+export const signupProcedure = (creds: Credentials = credentials['jonathan']) => {
     cy.visit('/auth/signup')
     cy.get(testName('signup-page'))
+
+    cy.intercept('POST', '/auth/signup').as('signup')
     typeSignupCredentialsAndSubmit(creds)
 }
 
@@ -19,8 +21,9 @@ export const typeLoginCredentialsAndSubmit = (creds: Credentials = credentials['
     cy.get(testName('input-password')).type(creds.password)
     cy.get(testName('submit-button')).click()
 }
-export const login = (creds: Credentials = credentials['jonathan']) => {
+export const loginProcedure = (creds: Credentials = credentials['jonathan']) => {
     cy.visit('/auth/login')
     cy.get(testName('login-page'))
+    cy.intercept('POST', '/auth/login').as('login')
     typeLoginCredentialsAndSubmit(creds)
 }

--- a/client-v2/cypress/support/commands.ts
+++ b/client-v2/cypress/support/commands.ts
@@ -10,6 +10,7 @@ declare namespace Cypress {
     interface Chainable<Subject = any> {
         setLocalStorage: typeof setLocalStorage
         clearDb: typeof clearDb
+        signup: typeof signup
     }
 }
 
@@ -22,9 +23,24 @@ function setLocalStorage(itemName: string, itemValue: string) {
 Cypress.Commands.add('setLocalStorage', setLocalStorage)
 
 function clearDb() {
-    cy.request('http://localhost:3001/clear-db')
+    cy.request('http://localhost:3001/clear-db').as('clearDb')
 }
 Cypress.Commands.add('clearDb', clearDb)
+
+function signup() {
+    const signupDto = {
+        email: 'jonathan.butler@cy.com',
+        username: 'Jonathan Butler',
+        password: 'Password-123',
+    }
+    cy.request({ method: 'POST', url: 'http://localhost:3001/auth/signup', body: signupDto })
+        .as('shadow-signup')
+        .then(res => {
+            // token needs to be JSON parsable
+            cy.setLocalStorage('rockket-auth-token', `${JSON.stringify(res.body.user.authToken)}`)
+        })
+}
+Cypress.Commands.add('signup', signup)
 
 //
 // ***********************************************

--- a/server/package.json
+++ b/server/package.json
@@ -25,7 +25,8 @@
         "unit:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
         "e2e": "sh run-e2e.sh '--watch --config ./test/jest-e2e.json'",
         "e2e:ci": "sh run-e2e.sh '--config ./test/jest-e2e.json'",
-        "db:reset": "prisma db push --force-reset --accept-data-loss --skip-generate"
+        "db:reset": "prisma db push --force-reset --accept-data-loss --skip-generate",
+        "db-testing:reset": "DATABASE_URL=$(bash ./get-testing-db-url.sh) npm run db:reset"
     },
     "dependencies": {
         "@nestjs/common": "^9.0.11",

--- a/server/src/app.service.ts
+++ b/server/src/app.service.ts
@@ -15,10 +15,10 @@ export class AppService {
         return 'Hello World!'
     }
 
-    clearDb() {
+    async clearDb() {
         if (this.configService.get('TESTING_ENV') != 'true') throw new ForbiddenException()
 
-        this.dbHelper.clearDb()
+        await this.dbHelper.clearDb()
         this.logger.verbose('Cleared database')
         return { message: 'Database cleared.' }
     }

--- a/server/src/prisma-abstractions/db-helper.ts
+++ b/server/src/prisma-abstractions/db-helper.ts
@@ -41,17 +41,14 @@ export class DbHelper {
         let names = await tableNames
         names ||= await this.getTables()
 
-        names.forEach(async (tableName) => {
+        console.time(`CLEARED DATABASE`)
+        for (const tableName of names) {
+            console.time(`TRUNCATE table ${tableName}`)
             await this.prisma.$executeRawUnsafe(`TRUNCATE TABLE "public"."${tableName}" CASCADE;`)
-        })
+            console.timeEnd(`TRUNCATE table ${tableName}`)
+        }
+        console.timeEnd(`CLEARED DATABASE`)
 
-        // Reset the autoincrement I guess (we're using uuids anyway)
-        // const relnames = await this.prisma
-        //     .$queryRaw`SELECT c.relname FROM pg_class AS c JOIN pg_namespace AS n ON c.relnamespace = n.oid WHERE c.relkind='S' AND n.nspname='${this.dbSchemaName}';`
-        // for (const { relname } of relnames as { relname: string }[]) {
-        //     await this.prisma
-        //         .$queryRaw`ALTER SEQUENCE \"${this.dbSchemaName}\".\"${relname}\" RESTART WITH 1;`
-        // }
         return this.disconnect
     }
 }


### PR DESCRIPTION
Resolves #144 

### Changes/Additions
- Wait for database truncate to finish
- Add signup command to speed things up and make it more isolated
- Reduce typing delay for auth procedures to 5ms
- Add `db-testing:reset` npm script